### PR TITLE
chore: record frontend build manifest 1.0.0

### DIFF
--- a/version_manifest.yml
+++ b/version_manifest.yml
@@ -2,5 +2,12 @@
 # Build manifest for traceability.
 # Records release version -> source commit hash mapping per service.
 
-frontend: {}
+frontend:
+  1.0.0:
+    source_ref: main
+    source_sha: ca0ca9a13924b51ddf415636e94b25b112144412
+    artifact_name: frontend-dist-1.0.0
+    build_run_id: "23803877173"
+    build_workflow: Build Frontend
+    updated_at_utc: ""
 backend: {}


### PR DESCRIPTION
Update `version_manifest.yml` for frontend build.

- version: `1.0.0`
- ref: `main`
- source sha: `ca0ca9a13924b51ddf415636e94b25b112144412`
- run id: `23803877173`