### PR TITLE
chore: record backend build manifest 1.0.0

### DIFF
--- a/version_manifest.yml
+++ b/version_manifest.yml
@@ -3,4 +3,11 @@
 # Records release version -> source commit hash mapping per service.
 
 frontend: {}
-backend: {}
+backend:
+  1.0.0:
+    source_ref: main
+    source_sha: 4816aaa74c3262e39aa3caf2e4ae967b697bcb80
+    image: ghcr.io/s-hikonyan-sys/art-gallery-backend:1.0.0
+    build_run_id: "23803869233"
+    build_workflow: Build Backend Image
+    updated_at_utc: ""


### PR DESCRIPTION
Update `version_manifest.yml` for backend build.

- version: `1.0.0`
- ref: `main`
- source sha: `4816aaa74c3262e39aa3caf2e4ae967b697bcb80`
- image: `ghcr.io/s-hikonyan-sys/art-gallery-backend:1.0.0`
- run id: `23803869233`