### PR TITLE
chore: register backend code version 1.0.0

### DIFF
--- a/backend_code_manifest.yml
+++ b/backend_code_manifest.yml
@@ -3,4 +3,10 @@
 # code_version (key) -> source_ref, source_sha recorded at registration.
 # Register: .github/workflows/register_backend_code.yml (PR)
 
-backend_code: {}
+backend_code:
+  1.0.0:
+    source_ref: main
+    source_sha: 4816aaa74c3262e39aa3caf2e4ae967b697bcb80
+    registered_by_run_id: "24200578893"
+    registered_by_workflow: Register Backend Code Version
+    registered_at_utc: ""


### PR DESCRIPTION
Update `backend_code_manifest.yml`.

- code_version: `1.0.0`
- ref: `main`
- source sha: `4816aaa74c3262e39aa3caf2e4ae967b697bcb80`
- run id: `24200578893`