### PR TITLE
chore: record backend build manifest 1.0.0

### DIFF
--- a/manifest/backend/image/backend_version_manifest.yml
+++ b/manifest/backend/image/backend_version_manifest.yml
@@ -7,6 +7,6 @@ backend:
     source_ref: main
     source_sha: 4816aaa74c3262e39aa3caf2e4ae967b697bcb80
     image: ghcr.io/s-hikonyan-sys/art-gallery-backend:1.0.0
-    build_run_id: "23854596849"
+    build_run_id: "24284622251"
     build_workflow: Build Backend Image
     updated_at_utc: ""


### PR DESCRIPTION
Update `manifest/backend/image/backend_version_manifest.yml` for backend build.

- version: `1.0.0`
- ref: `main`
- source sha: `4816aaa74c3262e39aa3caf2e4ae967b697bcb80`
- image: `ghcr.io/s-hikonyan-sys/art-gallery-backend:1.0.0`
- run id: `24284622251`