### PR TITLE
chore: record secrets build manifest 1.0.0

### DIFF
--- a/manifest/secrets/image/secrets_version_manifest.yml
+++ b/manifest/secrets/image/secrets_version_manifest.yml
@@ -2,4 +2,11 @@
 # Secrets API build manifest
 # Records release version -> source commit hash mapping.
 
-secrets: {}
+secrets:
+  1.0.0:
+    source_ref: main
+    source_sha: ""
+    image: ghcr.io/s-hikonyan-sys/art-gallery-secrets:1.0.0
+    build_run_id: "24570580247"
+    build_workflow: Build Secrets API Image
+    updated_at_utc: ""


### PR DESCRIPTION
Update `manifest/secrets/image/secrets_version_manifest.yml` for secrets build.

- version: `1.0.0`
- ref: `main`
- source sha: ``
- image: `ghcr.io/s-hikonyan-sys/art-gallery-secrets:1.0.0`
- run id: `24570580247`