### PR TITLE
chore: record database build manifest 1.0.0

### DIFF
--- a/manifest/database/image/database_version_manifest.yml
+++ b/manifest/database/image/database_version_manifest.yml
@@ -2,4 +2,11 @@
 # Database build manifest
 # Records release version -> source commit hash mapping.
 
-database: {}
+database:
+  1.0.0:
+    source_ref: main
+    source_sha: abb6e9cc0c0e5cf5c248b214b52552f1fc766688
+    image: ghcr.io/s-hikonyan-sys/art-gallery-database:1.0.0
+    build_run_id: "24571112258"
+    build_workflow: Build Database Image
+    updated_at_utc: ""


### PR DESCRIPTION
Update `manifest/database/image/database_version_manifest.yml` for database build.

- version: `1.0.0`
- ref: `main`
- source sha: `abb6e9cc0c0e5cf5c248b214b52552f1fc766688`
- image: `ghcr.io/s-hikonyan-sys/art-gallery-database:1.0.0`
- run id: `24571112258`