### PR TITLE
chore: record frontend build manifest 1.0.0

### DIFF
--- a/manifest/frontend/image/frontend_version_manifest.yml
+++ b/manifest/frontend/image/frontend_version_manifest.yml
@@ -7,6 +7,6 @@ frontend:
     source_ref: main
     source_sha: ca0ca9a13924b51ddf415636e94b25b112144412
     artifact_name: frontend-dist-1.0.0
-    build_run_id: "23854604990"
+    build_run_id: "24781153890"
     build_workflow: Build Frontend
     updated_at_utc: ""


### PR DESCRIPTION
Update `manifest/frontend/image/frontend_version_manifest.yml` for frontend build.

- version: `1.0.0`
- ref: `main`
- source sha: `ca0ca9a13924b51ddf415636e94b25b112144412`
- artifact: `frontend-dist-1.0.0`
- run id: `24781153890`

Workflow run: https://github.com/s-hikonyan-sys/art-gallery-release-tools/actions/runs/24781153890
