### PR TITLE
chore: register secrets code version 1.0.0

### DIFF
--- a/manifest/secrets/code/secrets_code_manifest.yml
+++ b/manifest/secrets/code/secrets_code_manifest.yml
@@ -8,6 +8,6 @@ secrets_code:
   1.0.0:
     source_ref: main
     source_sha: 6b19540610dc5798aca24bd631b16bb418adb2b3
-    registered_by_run_id: "24570685795"
+    registered_by_run_id: "24782378973"
     registered_by_workflow: Register Secrets API Code Version
     registered_at_utc: ""


### PR DESCRIPTION
Update `manifest/secrets/code/secrets_code_manifest.yml` for secrets code.

- code_version: `1.0.0`
- ref: `main`
- source sha: `6b19540610dc5798aca24bd631b16bb418adb2b3`
- run id: `24782378973`