### PR TITLE
chore: register backend code version 1.0.0

### DIFF
--- a/manifest/backend/code/backend_code_manifest.yml
+++ b/manifest/backend/code/backend_code_manifest.yml
@@ -7,6 +7,6 @@ backend_code:
   1.0.0:
     source_ref: main
     source_sha: 4816aaa74c3262e39aa3caf2e4ae967b697bcb80
-    registered_by_run_id: "24933417969"
+    registered_by_run_id: "24956742193"
     registered_by_workflow: Register Backend Code Version
     registered_at_utc: ""


### PR DESCRIPTION
Update `manifest/backend/code/backend_code_manifest.yml`.

- code_version: `1.0.0`
- ref: `main`
- source sha: `4816aaa74c3262e39aa3caf2e4ae967b697bcb80`
- run id: `24956742193`