### PR TITLE
chore: record secrets build manifest 1.0.0

### DIFF
--- a/manifest/secrets/image/secrets_version_manifest.yml
+++ b/manifest/secrets/image/secrets_version_manifest.yml
@@ -7,6 +7,6 @@ secrets:
     source_ref: main
     source_sha: ""
     image: ghcr.io/s-hikonyan-sys/art-gallery-secrets:1.0.0
-    build_run_id: "25106617780"
+    build_run_id: "25207221558"
     build_workflow: Build Secrets API Image
     updated_at_utc: ""


### PR DESCRIPTION
Update `manifest/secrets/image/secrets_version_manifest.yml` for secrets build.

- version: `1.0.0`
- ref: `main`
- source sha: ``
- image: `ghcr.io/s-hikonyan-sys/art-gallery-secrets:1.0.0`
- run id: `25207221558`

Workflow run: https://github.com/s-hikonyan-sys/art-gallery-release-tools/actions/runs/25207221558
