### PR TITLE
chore: record backend build manifest 1.0.0

### DIFF
--- a/manifest/backend/image/backend_version_manifest.yml
+++ b/manifest/backend/image/backend_version_manifest.yml
@@ -7,6 +7,6 @@ backend:
     source_ref: main
     source_sha: 4816aaa74c3262e39aa3caf2e4ae967b697bcb80
     image: ghcr.io/s-hikonyan-sys/art-gallery-backend:1.0.0
-    build_run_id: "25548729440"
+    build_run_id: "26038996377"
     build_workflow: Build Backend Image
     updated_at_utc: ""


### PR DESCRIPTION
Update `manifest/backend/image/backend_version_manifest.yml` for backend build.

- version: `1.0.0`
- ref: `main`
- source sha: `4816aaa74c3262e39aa3caf2e4ae967b697bcb80`
- image: `ghcr.io/s-hikonyan-sys/art-gallery-backend:1.0.0`
- run id: `26038996377`

Workflow run: https://github.com/s-hikonyan-sys/art-gallery-release-tools/actions/runs/26038996377
