### PR TITLE
chore: register nginx code version 1.0.0

### DIFF
--- a/manifest/nginx/code/nginx_code_manifest.yml
+++ b/manifest/nginx/code/nginx_code_manifest.yml
@@ -7,6 +7,6 @@ nginx_code:
   1.0.0:
     source_ref: main
     source_sha: 6696f2012636de1062a548364a48edd017eeba8d
-    registered_by_run_id: "26165805167"
+    registered_by_run_id: "26218206555"
     registered_by_workflow: Register Nginx Code Version
     registered_at_utc: ""


### PR DESCRIPTION
Update `manifest/nginx/code/nginx_code_manifest.yml`.

- code_version: `1.0.0`
- ref: `main`
- source sha: `6696f2012636de1062a548364a48edd017eeba8d`
- run id: `26218206555`