### PR TITLE
chore: register secrets code version 1.0.0

### DIFF
--- a/manifest/secrets/code/secrets_code_manifest.yml
+++ b/manifest/secrets/code/secrets_code_manifest.yml
@@ -8,6 +8,6 @@ secrets_code:
   1.0.0:
     source_ref: main
     source_sha: 43ce6aab87c7279fa4976ee2ff3c0165e10c114c
-    registered_by_run_id: "26335279128"
+    registered_by_run_id: "26577041043"
     registered_by_workflow: Register Secrets API Code Version
     registered_at_utc: ""


### PR DESCRIPTION
Update `manifest/secrets/code/secrets_code_manifest.yml` for secrets code.

- code_version: `1.0.0`
- ref: `main`
- source sha: `43ce6aab87c7279fa4976ee2ff3c0165e10c114c`
- run id: `26577041043`