### PR TITLE
chore: record backend build manifest 1.0.0

### DIFF
--- a/manifest/backend/image/backend_version_manifest.yml
+++ b/manifest/backend/image/backend_version_manifest.yml
@@ -5,8 +5,8 @@
 backend:
   1.0.0:
     source_ref: main
-    source_sha: 4816aaa74c3262e39aa3caf2e4ae967b697bcb80
+    source_sha: 5ec8e1645e2970cce3cb4624228b262ec0b5e67e
     image: ghcr.io/s-hikonyan-sys/art-gallery-backend:1.0.0
-    build_run_id: "26038996377"
+    build_run_id: "27089973878"
     build_workflow: Build Backend Image
     updated_at_utc: ""


### PR DESCRIPTION
Update `manifest/backend/image/backend_version_manifest.yml` for backend build.

- version: `1.0.0`
- ref: `main`
- source sha: `5ec8e1645e2970cce3cb4624228b262ec0b5e67e`
- image: `ghcr.io/s-hikonyan-sys/art-gallery-backend:1.0.0`
- run id: `27089973878`

Workflow run: https://github.com/s-hikonyan-sys/art-gallery-release-tools/actions/runs/27089973878
